### PR TITLE
Simplify notes dashboard front end

### DIFF
--- a/notes-api/src/app.js
+++ b/notes-api/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
+const path = require('path');
 require('dotenv').config();
 const {swaggerUI, specs} = require('./config/swagger');
 
@@ -15,6 +16,8 @@ app.use(morgan('combined')); // Logging
 app.use(express.json()); // Parse JSON bodies
 app.use(express.urlencoded({ extended: true })); // Parse URL-encoded bodies
 
+app.use('/app', express.static(path.join(__dirname, 'public')));
+
 app.use('/api/notes', notesRoutes);
 
 // Basic route
@@ -23,6 +26,7 @@ app.get('/', (req, res) => {
     message: 'Welcome to Notes API',
     version: '1.0.0',
     status: 'running',
+    frontend: '/app',
   });
 });
 

--- a/notes-api/src/public/app.js
+++ b/notes-api/src/public/app.js
@@ -1,0 +1,631 @@
+(() => {
+  const API_ROOT = resolveApiRoot();
+  const ENDPOINTS = {
+    notes: `${API_ROOT}/api/notes`,
+    categories: `${API_ROOT}/api/notes/categories`,
+    health: `${API_ROOT}/health`,
+  };
+
+  const state = {
+    notes: [],
+    categories: [],
+    pagination: null,
+    editingId: null,
+    messageTimer: null,
+    filters: {
+      search: '',
+      category: '',
+      priority: '',
+      pinned: 'all',
+      archived: 'false',
+      limit: 50,
+    },
+  };
+
+  const elements = {
+    form: document.getElementById('noteForm'),
+    formHeading: document.getElementById('formHeading'),
+    submitButton: document.getElementById('submitNote'),
+    cancelButton: document.getElementById('cancelEdit'),
+    titleInput: document.getElementById('titleInput'),
+    contentInput: document.getElementById('contentInput'),
+    categoryInput: document.getElementById('categoryInput'),
+    priorityInput: document.getElementById('priorityInput'),
+    tagsInput: document.getElementById('tagsInput'),
+    pinnedInput: document.getElementById('pinnedInput'),
+    archivedInput: document.getElementById('archivedInput'),
+    categoryOptions: document.getElementById('categoryOptions'),
+    searchInput: document.getElementById('searchInput'),
+    categoryFilter: document.getElementById('categoryFilter'),
+    priorityFilter: document.getElementById('priorityFilter'),
+    pinnedFilter: document.getElementById('pinnedFilter'),
+    archivedFilter: document.getElementById('archivedFilter'),
+    notesList: document.getElementById('notesList'),
+    notesSummary: document.getElementById('notesSummary'),
+    notification: document.getElementById('notification'),
+    apiStatus: document.getElementById('apiStatus'),
+  };
+
+  init();
+
+  function init() {
+    if (!elements.form) return;
+
+    setStatus('loading', 'Checking API…');
+    updateFormMode();
+    registerEventListeners();
+    refreshNotes();
+    loadCategories();
+    checkApiHealth();
+    setInterval(checkApiHealth, 60_000);
+  }
+
+  function registerEventListeners() {
+    elements.form.addEventListener('submit', handleFormSubmit);
+    elements.cancelButton.addEventListener('click', cancelEditMode);
+
+    if (elements.notification) {
+      elements.notification.addEventListener('click', hideNotification);
+    }
+
+    const debouncedSearch = debounce(() => {
+      state.filters.search = elements.searchInput.value.trim();
+      refreshNotes();
+    }, 300);
+    elements.searchInput.addEventListener('input', debouncedSearch);
+
+    elements.categoryFilter.addEventListener('change', event => {
+      state.filters.category = event.target.value;
+      refreshNotes();
+    });
+
+    elements.priorityFilter.addEventListener('change', event => {
+      state.filters.priority = event.target.value;
+      refreshNotes();
+    });
+
+    elements.pinnedFilter.addEventListener('change', event => {
+      state.filters.pinned = event.target.value || 'all';
+      refreshNotes();
+    });
+
+    elements.archivedFilter.addEventListener('change', event => {
+      state.filters.archived = event.target.value || 'false';
+      refreshNotes();
+    });
+  }
+
+  async function refreshNotes() {
+    setNotesPlaceholder('loading', 'Loading notes…');
+
+    try {
+      const params = new URLSearchParams();
+      params.set('limit', String(state.filters.limit));
+      params.set('archived', state.filters.archived);
+
+      if (state.filters.search) params.set('search', state.filters.search);
+      if (state.filters.category) params.set('category', state.filters.category);
+      if (state.filters.priority) params.set('priority', state.filters.priority);
+      if (state.filters.pinned !== 'all') params.set('pinned', state.filters.pinned);
+
+      const response = await fetchJson(`${ENDPOINTS.notes}?${params.toString()}`);
+      state.notes = Array.isArray(response?.data) ? response.data : [];
+      state.pagination = response?.pagination || null;
+      renderNotes();
+      setStatus('ok', 'API ready');
+    } catch (error) {
+      console.error('Failed to load notes:', error);
+      state.notes = [];
+      state.pagination = null;
+      setNotesPlaceholder('error', 'Unable to load notes. Please try again.');
+      showNotification(error.message || 'Unable to load notes.', 'error');
+      if (isNetworkError(error)) {
+        setStatus('error', 'Cannot reach API');
+      }
+    }
+  }
+
+  async function loadCategories() {
+    try {
+      const response = await fetchJson(ENDPOINTS.categories);
+      const categories = Array.isArray(response?.data) ? response.data : [];
+      state.categories = [...new Set(categories.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+      renderCategoryControls();
+    } catch (error) {
+      console.warn('Unable to fetch categories:', error);
+    }
+  }
+
+  function renderCategoryControls() {
+    if (!elements.categoryOptions) return;
+
+    elements.categoryOptions.innerHTML = '';
+    state.categories.forEach(category => {
+      const option = document.createElement('option');
+      option.value = category;
+      elements.categoryOptions.appendChild(option);
+    });
+
+    if (!elements.categoryFilter) return;
+
+    const current = elements.categoryFilter.value;
+    elements.categoryFilter.innerHTML = '';
+
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = 'All categories';
+    elements.categoryFilter.appendChild(defaultOption);
+
+    const categories = [...state.categories];
+    if (state.filters.category && !categories.includes(state.filters.category)) {
+      categories.push(state.filters.category);
+    }
+
+    categories.sort((a, b) => a.localeCompare(b));
+
+    categories.forEach(category => {
+      const option = document.createElement('option');
+      option.value = category;
+      option.textContent = category;
+      if (category === current || category === state.filters.category) {
+        option.selected = true;
+      }
+      elements.categoryFilter.appendChild(option);
+    });
+  }
+
+  function renderNotes() {
+    updateSummary();
+
+    if (!state.notes.length) {
+      setNotesPlaceholder('empty', 'No notes match your current filters.');
+      return;
+    }
+
+    elements.notesList.dataset.state = 'ready';
+    elements.notesList.innerHTML = '';
+
+    const fragment = document.createDocumentFragment();
+    state.notes.forEach(note => {
+      fragment.appendChild(createNoteCard(note));
+    });
+
+    elements.notesList.appendChild(fragment);
+  }
+
+  function createNoteCard(note) {
+    const card = document.createElement('article');
+    card.className = 'note-card';
+    card.dataset.pinned = note.isPinned ? 'true' : 'false';
+    card.dataset.archived = note.isArchived ? 'true' : 'false';
+
+    const header = document.createElement('div');
+    header.className = 'note-card__head';
+
+    const title = document.createElement('h3');
+    title.className = 'note-card__title';
+    title.textContent = note.title || 'Untitled note';
+    header.appendChild(title);
+
+    const badges = document.createElement('div');
+    badges.className = 'badges';
+
+    if (note.category) {
+      badges.appendChild(createBadge(note.category));
+    }
+
+    if (note.priority) {
+      badges.appendChild(createBadge(capitalize(note.priority), `badge--priority-${note.priority}`));
+    }
+
+    if (note.isPinned) {
+      badges.appendChild(createBadge('Pinned', 'badge--state'));
+    }
+
+    if (note.isArchived) {
+      badges.appendChild(createBadge('Archived', 'badge--archived'));
+    }
+
+    if (badges.childElementCount > 0) {
+      header.appendChild(badges);
+    }
+
+    card.appendChild(header);
+
+    const content = document.createElement('p');
+    content.className = 'note-card__content';
+    content.textContent = note.content || '';
+    card.appendChild(content);
+
+    const tags = Array.isArray(note.tags) ? note.tags.filter(Boolean) : [];
+    if (tags.length) {
+      const tagsContainer = document.createElement('div');
+      tagsContainer.className = 'note-card__tags';
+      tags.forEach(tag => {
+        const tagElement = document.createElement('span');
+        tagElement.textContent = tag;
+        tagsContainer.appendChild(tagElement);
+      });
+      card.appendChild(tagsContainer);
+    }
+
+    const footer = document.createElement('footer');
+    footer.className = 'note-card__footer';
+
+    const meta = document.createElement('div');
+    meta.className = 'note-card__meta';
+
+    const updatedSpan = document.createElement('span');
+    updatedSpan.textContent = `Updated ${formatRelative(note.updatedAt)}`;
+    updatedSpan.title = formatAbsolute(note.updatedAt);
+    meta.appendChild(updatedSpan);
+
+    const createdSpan = document.createElement('span');
+    createdSpan.textContent = `Created ${formatRelative(note.createdAt)}`;
+    createdSpan.title = formatAbsolute(note.createdAt);
+    meta.appendChild(createdSpan);
+
+    footer.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'note-card__actions';
+
+    actions.appendChild(createActionButton('Edit', () => enterEditMode(note)));
+    actions.appendChild(
+      createActionButton(note.isPinned ? 'Unpin' : 'Pin', () => togglePin(note))
+    );
+    actions.appendChild(
+      createActionButton(note.isArchived ? 'Restore' : 'Archive', () => toggleArchive(note))
+    );
+    actions.appendChild(createActionButton('Delete', () => deleteNote(note), 'danger'));
+
+    footer.appendChild(actions);
+    card.appendChild(footer);
+
+    return card;
+  }
+
+  function createBadge(text, extraClass = '') {
+    const badge = document.createElement('span');
+    badge.className = `badge ${extraClass}`.trim();
+    badge.textContent = text;
+    return badge;
+  }
+
+  function createActionButton(label, handler, extraClass = '') {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    if (extraClass) {
+      button.classList.add(extraClass);
+    }
+    button.addEventListener('click', handler);
+    return button;
+  }
+
+  function updateSummary() {
+    if (!elements.notesSummary) return;
+    const totalShown = state.notes.length;
+    const totalPinned = state.notes.filter(note => note.isPinned).length;
+    const totalItems = state.pagination?.totalItems ?? totalShown;
+    const currentPage = state.pagination?.currentPage ?? 1;
+    const totalPages = state.pagination?.totalPages ?? 1;
+
+    elements.notesSummary.textContent = `${totalShown} ${totalShown === 1 ? 'note' : 'notes'} shown • ${totalPinned} pinned • Page ${currentPage} of ${totalPages} • Total ${totalItems}`;
+  }
+
+  function updateFormMode() {
+    const isEditing = Boolean(state.editingId);
+    elements.formHeading.textContent = isEditing ? 'Edit note' : 'Create a note';
+    elements.submitButton.textContent = isEditing ? 'Update note' : 'Create note';
+    elements.cancelButton.classList.toggle('hidden', !isEditing);
+    elements.archivedInput.disabled = !isEditing;
+
+    if (!isEditing) {
+      elements.archivedInput.checked = false;
+    }
+  }
+
+  function enterEditMode(note) {
+    state.editingId = note.id;
+    elements.titleInput.value = note.title || '';
+    elements.contentInput.value = note.content || '';
+    elements.categoryInput.value = note.category || '';
+    elements.priorityInput.value = note.priority || 'medium';
+    elements.tagsInput.value = (Array.isArray(note.tags) ? note.tags : []).join(', ');
+    elements.pinnedInput.checked = Boolean(note.isPinned);
+    elements.archivedInput.checked = Boolean(note.isArchived);
+    elements.archivedInput.disabled = false;
+    updateFormMode();
+    showNotification('Editing existing note. Submit to save changes.', 'info');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function cancelEditMode() {
+    resetForm();
+    showNotification('Cancelled editing mode.', 'info');
+  }
+
+  function resetForm() {
+    elements.form.reset();
+    elements.priorityInput.value = 'medium';
+    elements.tagsInput.value = '';
+    elements.pinnedInput.checked = false;
+    elements.archivedInput.checked = false;
+    elements.archivedInput.disabled = true;
+    state.editingId = null;
+    updateFormMode();
+  }
+
+  async function handleFormSubmit(event) {
+    event.preventDefault();
+
+    const payload = buildPayload();
+    if (!payload.title || !payload.content) {
+      showNotification('Title and content are required.', 'error');
+      return;
+    }
+
+    elements.submitButton.disabled = true;
+    try {
+      if (state.editingId) {
+        await updateExistingNote(payload);
+      } else {
+        await createNewNote(payload);
+      }
+      resetForm();
+      await refreshNotes();
+      await loadCategories();
+    } catch (error) {
+      console.error('Failed to save note:', error);
+      showNotification(error.message || 'Unable to save note.', 'error');
+      if (isNetworkError(error)) {
+        setStatus('error', 'Cannot reach API');
+      }
+    } finally {
+      elements.submitButton.disabled = false;
+    }
+  }
+
+  function buildPayload() {
+    const title = elements.titleInput.value.trim();
+    const content = elements.contentInput.value.trim();
+    const category = elements.categoryInput.value.trim();
+    const priority = (elements.priorityInput.value || 'medium').toLowerCase();
+    const tags = parseTags(elements.tagsInput.value);
+    const isPinned = Boolean(elements.pinnedInput.checked);
+    const isArchived = Boolean(elements.archivedInput.checked);
+
+    const payload = {
+      title,
+      content,
+      priority,
+      tags,
+      isPinned,
+    };
+
+    if (category) {
+      payload.category = category;
+    }
+
+    if (state.editingId) {
+      payload.isArchived = isArchived;
+    }
+
+    return payload;
+  }
+
+  async function createNewNote(payload) {
+    const response = await fetchJson(ENDPOINTS.notes, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    showNotification(response?.message || 'Note created successfully.', 'success');
+  }
+
+  async function updateExistingNote(payload) {
+    const response = await fetchJson(`${ENDPOINTS.notes}/${state.editingId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    showNotification(response?.message || 'Note updated successfully.', 'success');
+    state.editingId = null;
+    updateFormMode();
+  }
+
+  async function togglePin(note) {
+    try {
+      const response = await fetchJson(`${ENDPOINTS.notes}/${note.id}/pin`, { method: 'PATCH' });
+      showNotification(response?.message || `Note ${note.isPinned ? 'unpinned' : 'pinned'}.`, 'success');
+      await refreshNotes();
+    } catch (error) {
+      console.error('Failed to toggle pin:', error);
+      showNotification(error.message || 'Unable to update pin status.', 'error');
+    }
+  }
+
+  async function toggleArchive(note) {
+    try {
+      const response = await fetchJson(`${ENDPOINTS.notes}/${note.id}/archive`, { method: 'PATCH' });
+      showNotification(response?.message || `Note ${note.isArchived ? 'restored' : 'archived'}.`, 'success');
+      if (state.editingId === note.id) {
+        resetForm();
+      }
+      await refreshNotes();
+    } catch (error) {
+      console.error('Failed to toggle archive:', error);
+      showNotification(error.message || 'Unable to update archive status.', 'error');
+    }
+  }
+
+  async function deleteNote(note) {
+    const confirmed = window.confirm('Are you sure you want to permanently delete this note?');
+    if (!confirmed) return;
+
+    try {
+      const response = await fetchJson(`${ENDPOINTS.notes}/${note.id}`, { method: 'DELETE' });
+      showNotification(response?.message || 'Note deleted successfully.', 'success');
+      if (state.editingId === note.id) {
+        resetForm();
+      }
+      await refreshNotes();
+      await loadCategories();
+    } catch (error) {
+      console.error('Failed to delete note:', error);
+      showNotification(error.message || 'Unable to delete note.', 'error');
+    }
+  }
+
+  async function checkApiHealth() {
+    try {
+      const response = await fetchJson(ENDPOINTS.health);
+      const uptime = typeof response?.uptime === 'number' ? formatUptime(response.uptime) : null;
+      setStatus('ok', uptime ? `API healthy • Uptime ${uptime}` : 'API healthy');
+    } catch (error) {
+      setStatus('error', 'Unable to reach API');
+    }
+  }
+
+  async function fetchJson(url, options) {
+    const response = await fetch(url, options);
+    const text = await response.text();
+    let data = null;
+
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch (parseError) {
+        data = null;
+      }
+    }
+
+    if (!response.ok) {
+      const message = data?.message || response.statusText || 'Request failed';
+      const error = new Error(message);
+      error.status = response.status;
+      error.body = data;
+      throw error;
+    }
+
+    return data;
+  }
+
+  function setNotesPlaceholder(stateName, message) {
+    elements.notesList.dataset.state = stateName;
+    elements.notesList.innerHTML = `<p class="placeholder">${message}</p>`;
+    if (stateName === 'loading') {
+      elements.notesSummary.textContent = 'Loading notes…';
+    } else if (stateName === 'error') {
+      elements.notesSummary.textContent = 'Unable to load notes.';
+    }
+  }
+
+  function showNotification(message, type = 'info') {
+    if (!elements.notification) return;
+    elements.notification.textContent = message;
+    elements.notification.dataset.type = type;
+    elements.notification.classList.remove('hidden');
+
+    if (state.messageTimer) {
+      clearTimeout(state.messageTimer);
+    }
+
+    state.messageTimer = setTimeout(() => {
+      hideNotification();
+    }, 4000);
+  }
+
+  function hideNotification() {
+    if (!elements.notification) return;
+    elements.notification.classList.add('hidden');
+    if (state.messageTimer) {
+      clearTimeout(state.messageTimer);
+      state.messageTimer = null;
+    }
+  }
+
+  function setStatus(status, text) {
+    if (!elements.apiStatus) return;
+    elements.apiStatus.textContent = text;
+    elements.apiStatus.classList.remove('status--loading', 'status--ok', 'status--error');
+    elements.apiStatus.classList.add(`status--${status}`);
+  }
+
+  function parseTags(value) {
+    return value
+      .split(',')
+      .map(tag => tag.trim())
+      .filter(Boolean);
+  }
+
+  function capitalize(value) {
+    if (!value) return '';
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+
+  function formatRelative(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+
+    const diff = date.getTime() - Date.now();
+    const absDiff = Math.abs(diff);
+    const units = [
+      { unit: 'day', ms: 86_400_000 },
+      { unit: 'hour', ms: 3_600_000 },
+      { unit: 'minute', ms: 60_000 },
+    ];
+    const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+    for (const { unit, ms } of units) {
+      if (absDiff >= ms) {
+        const valueRounded = Math.round(diff / ms);
+        return formatter.format(valueRounded, unit);
+      }
+    }
+
+    return 'just now';
+  }
+
+  function formatAbsolute(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  }
+
+  function formatUptime(seconds) {
+    if (typeof seconds !== 'number' || Number.isNaN(seconds)) return '';
+    const hrs = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    return `${hrs}h ${mins}m`;
+  }
+
+  function isNetworkError(error) {
+    return (
+      error?.name === 'TypeError' ||
+      /NetworkError|Failed to fetch|Load failed|offline/i.test(error?.message || '')
+    );
+  }
+
+  function debounce(fn, wait = 300) {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(null, args), wait);
+    };
+  }
+
+  function resolveApiRoot() {
+    const origin = window.location.origin;
+    if (origin && origin.startsWith('http')) {
+      return origin.replace(/\/$/, '');
+    }
+    return 'http://localhost:3000';
+  }
+})();

--- a/notes-api/src/public/index.html
+++ b/notes-api/src/public/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notes API Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="page-header__text">
+        <h1>Notes API dashboard</h1>
+        <p class="muted">Create, edit, and organise notes stored in the Express backend.</p>
+      </div>
+      <span id="apiStatus" class="status status--loading">Checking API…</span>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <div class="panel__head">
+          <h2 id="formHeading">Create a note</h2>
+          <button type="button" id="cancelEdit" class="ghost-button hidden">Cancel edit</button>
+        </div>
+
+        <form id="noteForm" class="form" novalidate>
+          <div class="form__row">
+            <label class="field">
+              <span>Title <sup>*</sup></span>
+              <input id="titleInput" name="title" type="text" required placeholder="Write a short title" />
+            </label>
+            <label class="field">
+              <span>Category</span>
+              <input
+                id="categoryInput"
+                name="category"
+                type="text"
+                list="categoryOptions"
+                placeholder="e.g. work"
+                autocomplete="off"
+              />
+            </label>
+          </div>
+
+          <label class="field">
+            <span>Content <sup>*</sup></span>
+            <textarea
+              id="contentInput"
+              name="content"
+              rows="5"
+              required
+              placeholder="Add the full content of your note"
+            ></textarea>
+          </label>
+
+          <div class="form__row">
+            <label class="field">
+              <span>Priority</span>
+              <select id="priorityInput" name="priority">
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Tags (comma separated)</span>
+              <input id="tagsInput" name="tags" type="text" placeholder="planning,ideas" />
+            </label>
+          </div>
+
+          <div class="form__row form__row--inline">
+            <label class="checkbox">
+              <input id="pinnedInput" name="isPinned" type="checkbox" />
+              <span>Pin note</span>
+            </label>
+            <label class="checkbox" id="archivedField">
+              <input id="archivedInput" name="isArchived" type="checkbox" disabled />
+              <span>Archive note (only available when editing)</span>
+            </label>
+          </div>
+
+          <div class="form__actions">
+            <button type="submit" id="submitNote" class="primary-button">Create note</button>
+          </div>
+        </form>
+        <datalist id="categoryOptions"></datalist>
+      </section>
+
+      <section class="panel panel--list">
+        <div class="panel__head panel__head--stack">
+          <div>
+            <h2>Notes</h2>
+            <p id="notesSummary" class="muted">Loading notes…</p>
+          </div>
+          <div class="filters">
+            <label class="filters__item">
+              <span class="visually-hidden">Search notes</span>
+              <input id="searchInput" type="search" placeholder="Search title or content" />
+            </label>
+            <label class="filters__item">
+              <span class="visually-hidden">Filter by category</span>
+              <select id="categoryFilter">
+                <option value="">All categories</option>
+              </select>
+            </label>
+            <label class="filters__item">
+              <span class="visually-hidden">Filter by priority</span>
+              <select id="priorityFilter">
+                <option value="">All priorities</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+            <label class="filters__item">
+              <span class="visually-hidden">Filter by pinned state</span>
+              <select id="pinnedFilter">
+                <option value="all">Pinned + unpinned</option>
+                <option value="true">Pinned only</option>
+                <option value="false">Unpinned only</option>
+              </select>
+            </label>
+            <label class="filters__item">
+              <span class="visually-hidden">Filter by archived state</span>
+              <select id="archivedFilter">
+                <option value="false">Active notes</option>
+                <option value="true">Archived notes</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div id="notesList" class="notes-list" data-state="loading">
+          <p class="placeholder">Loading notes…</p>
+        </div>
+      </section>
+    </main>
+
+    <div id="notification" class="notification hidden" role="status" aria-live="polite"></div>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/notes-api/src/public/styles.css
+++ b/notes-api/src/public/styles.css
@@ -1,0 +1,504 @@
+:root {
+  color-scheme: light;
+  --background: #f4f6fb;
+  --panel: #ffffff;
+  --surface-strong: #0f172a;
+  --surface-soft: #1e293b;
+  --text: #111827;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --success: #16a34a;
+  --danger: #dc2626;
+  --warning: #f97316;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  --radius-lg: 20px;
+  --radius-md: 12px;
+  --radius-sm: 6px;
+  --transition: 0.18s ease-in-out;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--background);
+  color: var(--text);
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.page-header {
+  background: linear-gradient(135deg, var(--surface-strong), var(--surface-soft));
+  color: #f8fafc;
+  padding: 2.5rem clamp(1.25rem, 4vw, 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.25);
+}
+
+.page-header__text h1 {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+.page-header__text p {
+  margin-top: 0.35rem;
+  color: rgba(248, 250, 252, 0.82);
+  max-width: 38ch;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.12);
+}
+
+.status--loading {
+  color: #fbbf24;
+}
+
+.status--ok {
+  color: #34d399;
+  background: rgba(16, 185, 129, 0.16);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.status--error {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.layout {
+  display: grid;
+  gap: 2.25rem;
+  padding: clamp(1.75rem, 5vw, 3rem);
+  grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.panel__head--stack {
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  color: var(--surface-soft);
+  padding: 0.55rem 0.95rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color var(--transition), color var(--transition), background var(--transition);
+}
+
+.ghost-button:hover {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.4);
+  color: var(--primary-dark);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form__row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(0, min(240px, 100%)));
+}
+
+.form__row--inline {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+}
+
+.field > span {
+  font-weight: 500;
+  color: var(--surface-soft);
+}
+
+input,
+select,
+textarea {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 0.7rem 0.85rem;
+  background: #f9fafb;
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.65);
+  background: #ffffff;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.checkbox input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 4px;
+}
+
+.form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary-button {
+  border: none;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #fff;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(37, 99, 235, 0.2);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.filters__item {
+  display: inline-flex;
+}
+
+.filters__item input,
+.filters__item select {
+  min-width: 160px;
+}
+
+.panel--list {
+  gap: 1.25rem;
+}
+
+.notes-list {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.placeholder {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.note-card {
+  background: linear-gradient(160deg, #ffffff 0%, #f8fafc 100%);
+  border-radius: var(--radius-lg);
+  padding: 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.note-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+}
+
+.note-card[data-pinned='true'] {
+  border-color: rgba(245, 158, 11, 0.7);
+  box-shadow: 0 20px 38px rgba(245, 158, 11, 0.25);
+}
+
+.note-card[data-archived='true'] {
+  opacity: 0.75;
+}
+
+.note-card__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.note-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.note-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.badge {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--surface-soft);
+}
+
+.badge--priority-high {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.badge--priority-medium {
+  background: rgba(234, 179, 8, 0.18);
+  color: #b45309;
+}
+
+.badge--priority-low {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.badge--state {
+  background: rgba(5, 150, 105, 0.18);
+  color: #047857;
+}
+
+.badge--archived {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.note-card__content {
+  line-height: 1.55;
+  color: #1f2937;
+  white-space: pre-line;
+}
+
+.note-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.note-card__tags span {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-dark);
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+}
+
+.note-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.note-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.note-card__actions button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.75rem;
+  background: rgba(148, 163, 184, 0.22);
+  color: var(--surface-soft);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.note-card__actions button:hover {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--primary-dark);
+}
+
+.note-card__actions button.danger {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.note-card__actions button.danger:hover {
+  background: rgba(248, 113, 113, 0.28);
+}
+
+.notification {
+  position: fixed;
+  right: clamp(1rem, 4vw, 2rem);
+  bottom: clamp(1rem, 4vw, 2rem);
+  padding: 0.85rem 1.2rem;
+  border-radius: var(--radius-md);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+  background: var(--surface-soft);
+  color: #f8fafc;
+  font-weight: 500;
+  min-width: 240px;
+  max-width: 320px;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.notification[data-type='success'] {
+  background: var(--success);
+}
+
+.notification[data-type='error'] {
+  background: var(--danger);
+}
+
+.notification[data-type='info'] {
+  background: var(--surface-soft);
+}
+
+.notification.hidden {
+  opacity: 0;
+  transform: translateY(20px);
+  pointer-events: none;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .filters {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 680px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .filters__item input,
+  .filters__item select {
+    min-width: 140px;
+  }
+
+  .note-card__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the dashboard markup with a focused two-panel layout, filters, and notification area
- restyle the page with updated typography, responsive panels, and polished card interactions
- rewrite the client logic for loading, filtering, CRUD actions, toast messages, and API health checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5dd307648324a06a75e863ae4224